### PR TITLE
feat: add coverage display

### DIFF
--- a/.github/workflows/deploy-lambda.yml
+++ b/.github/workflows/deploy-lambda.yml
@@ -76,8 +76,11 @@ jobs:
 
       - name: Run Unit Tests
         if: inputs.test
+        env:
+          PYTHONPATH: .
         run: |
-          PYTHONPATH=. pipenv run coverage run -m pytest
+          pipenv run coverage run -m pytest
+          pipenv run coverage report --sort cover
 
 
       - name: Setup Node.js

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -62,5 +62,8 @@ jobs:
           docker-compose up -d  ${{ inputs.docker-compose }}
           sleep 10
       - name: Run Unit Tests
+        env:
+          PYTHONPATH: .
         run: |
-          PYTHONPATH=. pipenv run coverage run -m pytest
+          pipenv run coverage run -m pytest
+          pipenv run coverage report --sort cover


### PR DESCRIPTION
Adds a coverage display for both deploy and unit tests yml files, since using only the command
```
PYTHONPATH=. pipenv run coverage run -m pytest
```
does not display the coverage, it just generate a file named .coverage containing the results.
