### PR TITLE
feat: allow-unsynced

### DIFF
--- a/.github/workflows/deploy-lambda.yml
+++ b/.github/workflows/deploy-lambda.yml
@@ -86,7 +86,7 @@ jobs:
         # the first command is used to avoid https://github.com/python/mypy/issues/16363
         run: |
           pipenv run mypy ${{ inputs.project-path }} > /dev/null || true
-          pipenv run mypy ${{ inputs.project-path }} | pipenv run mypy-baseline filter
+          pipenv run mypy ${{ inputs.project-path }} | pipenv run mypy-baseline filter --allow-unsynced
 
       - name: Docker Compose UP
         if: inputs.docker-compose != ''

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -73,7 +73,7 @@ jobs:
         # the first command is used to avoid https://github.com/python/mypy/issues/16363
         run: |
           pipenv run mypy ${{ inputs.project-path }} > /dev/null || true
-          pipenv run mypy ${{ inputs.project-path }} | pipenv run mypy-baseline filter
+          pipenv run mypy ${{ inputs.project-path }} | pipenv run mypy-baseline filter --allow-unsynced
 
       - name: Docker Compose UP
         if: inputs.docker-compose != ''


### PR DESCRIPTION
Adiciona flag de --allow-unsynced para o mypy-baseline para que ele não trave PRs que consertaram erros do mypy mas não atualizaram o arquivo mypy-baseline.txt